### PR TITLE
Bugfix: usage deprecated function and wrong parameter name

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1909,7 +1909,7 @@ if ( !function_exists( 'leaky_paywall_email_subscription_status' ) ) {
     	
     	// if the args come through as a WP User object, then the user already exists in the system and we don't know their password
         if ( !empty( $args ) && is_array( $args ) ) {
-            $password = $args['user_pass'];
+            $password = $args['password'];
         } else {
 	        $password = '';
         }

--- a/include/registration-functions.php
+++ b/include/registration-functions.php
@@ -165,7 +165,7 @@ function leaky_paywall_process_registration() {
 			do_action( 'leaky_paywall_after_free_user_created', $user_data['id'], $_POST );
 
 			// log the new user in
-			wp_set_auth_cookie( $user_data['id']);
+			wp_set_auth_cookie( $user_data['id'], true);
 			wp_set_current_user( $user_data['id'], $user_data['login'] );
 			do_action( 'wp_login', $user_data['login'], $user_data );
 

--- a/include/registration-functions.php
+++ b/include/registration-functions.php
@@ -165,7 +165,7 @@ function leaky_paywall_process_registration() {
 			do_action( 'leaky_paywall_after_free_user_created', $user_data['id'], $_POST );
 
 			// log the new user in
-			wp_setcookie( $user_data['login'], $user_data['password'], true );
+			wp_set_auth_cookie( $user_data['id']);
 			wp_set_current_user( $user_data['id'], $user_data['login'] );
 			do_action( 'wp_login', $user_data['login'], $user_data );
 


### PR DESCRIPTION
Hi,

I've made some changes to replace the deprecated method wp_set_cookie with the new method wp_set_auth_cookie. And a warning was thrown because of a missing field user_pass in the args variable, replacing it with password fixed the error for me.