### PR TITLE
Fix the php warning from stripe/lib/ApiRequestor.php:242

### DIFF
--- a/deprecated.php
+++ b/deprecated.php
@@ -298,8 +298,8 @@ if ( !function_exists( 'leaky_paywall_process_stripe_payment' ) ) {
                 
                     $customer_array['plan'] = $level['plan_id'];
                     if ( !empty( $cu ) ) {
-                        $subscriptions = $cu->subscriptions->all( 'limit=1' );
-                        
+                        $subscriptions = $cu->subscriptions->all( array('limit' => '1') );
+
                         if ( !empty( $subscriptions->data ) ) {
                             foreach( $subscriptions->data as $subscription ) {
                                 $sub = $cu->subscriptions->retrieve( $subscription->id );

--- a/functions.php
+++ b/functions.php
@@ -461,7 +461,7 @@ if ( !function_exists( 'leaky_paywall_has_user_paid' ) ) {
 						
 						if ( !empty( $plan ) ) {
 							if ( isset( $cu->subscriptions ) ) {
-								$subscriptions = $cu->subscriptions->all( 'limit=1' );
+								$subscriptions = $cu->subscriptions->all( array('limit' => '1') );
 								foreach( $subscriptions->data as $subscription ) {
 									if ( 'active' === $subscription->status ) {
 										return 'subscription';
@@ -856,8 +856,8 @@ if ( !function_exists( 'leaky_paywall_cancellation_confirmation' ) ) {
 						if ( !empty( $cu ) )
 							if ( true === $cu->deleted )
 								throw new Exception( __( 'Unable to find valid Stripe customer ID to unsubscribe. Please contact support', 'issuem-leaky-paywall' ) );
-								
-						$subscriptions = $cu->subscriptions->all( 'limit=1' );
+
+						$subscriptions = $cu->subscriptions->all( array('limit' => '1') );
 
 						foreach( $subscriptions->data as $susbcription ) {
 							$sub = $cu->subscriptions->retrieve( $susbcription->id );

--- a/include/gateways/class-leaky-paywall-payment-gateway-stripe.php
+++ b/include/gateways/class-leaky-paywall-payment-gateway-stripe.php
@@ -125,8 +125,8 @@ class Leaky_Paywall_Payment_Gateway_Stripe extends Leaky_Paywall_Payment_Gateway
 				$customer_array['plan'] = $this->plan_id;
 
 				if ( !empty( $cu ) ) {
-					$subscriptions = $cu->subscriptions->all( 'limit=1' );
-					
+					$subscriptions = $cu->subscriptions->all( array('limit' => '1') );
+
 					if ( !empty( $subscriptions->data ) ) {
 						foreach( $subscriptions->data as $subscription ) {
 							$sub = $cu->subscriptions->retrieve( $subscription->id );

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -439,9 +439,9 @@ if ( !function_exists( 'do_leaky_paywall_profile' ) ) {
 							if ( empty( $_POST['stripe-cc-name'] ) ) {
 								throw new Exception( __( "Credit Card Cardholder's Name Required", 'issuem-leaky-paywall' ) );
 							}
-															
-							$subscriptions = $cu->subscriptions->all( 'limit=1' );
-	
+
+							$subscriptions = $cu->subscriptions->all( array('limit' => '1') );
+
 							foreach( $subscriptions->data as $susbcription ) {
 								$sub = $cu->subscriptions->retrieve( $susbcription->id );
 								$sub->card = array(


### PR DESCRIPTION
Fix the php warning
```
Warning: Invalid argument supplied for foreach() in wp-content/plugins/leaky-paywall/include/stripe/lib/ApiRequestor.php on line 242
```