### PR TITLE
Changed deprecated jQuery .live to .on()

### DIFF
--- a/js/issuem-leaky-paywall-post.js
+++ b/js/issuem-leaky-paywall-post.js
@@ -2,7 +2,7 @@ var $leaky_paywall_post = jQuery.noConflict();
 
 $leaky_paywall_post(document).ready(function($) {
 		
-	$( 'select#issuem-leaky-paywall-visibility-type' ).live( 'change', function( event ) {
+	$( '.inside' ).on( 'change', "#issuem-leaky-paywall-visibility-type", function( event ) {
 		var parent = $( this ).parent();
 		if ( 'default' == $( this ).val() ) {
 			$( 'select#issuem-leaky-paywall-only-visible' ).hide();


### PR DESCRIPTION
.live is from jQuery 1.9. It seems to still work in most environments but we have received instances where it isn't used anymore. Figured it is best to switch this to .on().