### PR TITLE
Corrected var causing new subscriber email to display wrong level.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2224,7 +2224,7 @@ if ( !function_exists( 'leaky_paywall_email_subscription_status' ) ) {
 				if ( 'off' === $settings['new_subscriber_admin_email'] ) {
 					// new user subscribe admin email
 
-					$level_id = get_user_meta( $user->ID, '_issuem_leaky_paywall_' . $mode . '_level_id' . $site, true );
+					$level_id = get_user_meta( $user_info->ID, '_issuem_leaky_paywall_' . $mode . '_level_id' . $site, true );
 					$level_name = stripcslashes( $settings['levels'][$level_id]['label'] );
 
 					$admin_raw_message = '<p>A new user has signed up on ' . $site_name . '.</p>


### PR DESCRIPTION
This issue was causing the new subscription email notification to display the wrong subscription level.