### PR TITLE
Get post type labels from object

### DIFF
--- a/shortcodes.php
+++ b/shortcodes.php
@@ -633,18 +633,20 @@ function do_leaky_paywall_register_form() {
 							if ( $i > 0 ) {
 								$content_access_description .= ', ';
 							}
+							
+							$post_type = get_post_type_object( $type['post_type'] );
 
 							if ( $type['allowed'] == 'unlimited' ) {
-								$content_access_description .= ucfirst( $type['allowed'] ) . ' ' . $type['post_type'] . 's';
+								$content_access_description .= ucfirst( $type['allowed'] ) . ' ' . $post_type->labels->name;
 							} else {
-								$content_access_description .= $type['allowed_value'] . ' ' . $type['post_type'] . 's';
+								$post_type_label = $type['allowed_value'] === '1' ? $post_type->labels->singular_name : $post_type->labels->name;
+								$content_access_description .= $type['allowed_value'] . ' ' . $post_type_label;
 							}
-							
+
 							$i++;
 						}	
 					}
-					
-					
+
 					echo apply_filters( 'leaky_paywall_content_access_description', $content_access_description, $level, $level_id );
 				?>	
 				


### PR DESCRIPTION
The current way to display the amount of a post type the user can read is to take the slug and append an s. This does not work nicely for all plural forms and is problematic when working with translations.