### PR TITLE
Use the correct capability name when checking if a user can edit pages.

### DIFF
--- a/metaboxes.php
+++ b/metaboxes.php
@@ -128,7 +128,7 @@ if ( !function_exists( 'save_leaky_paywall_content_visibility' ) ) {
 		}
 			
 		// Check the user's permissions.
-		if ( ! ( current_user_can( 'edit_page', $post_id ) || current_user_can( 'edit_posts', $post_id ) ) ) {
+		if ( ! ( current_user_can( 'edit_pages', $post_id ) || current_user_can( 'edit_posts', $post_id ) ) ) {
 			return;
 		}
 	


### PR DESCRIPTION
**Background**

When saving an Advanced Custom Fields field group, Leaky Paywall triggers notice/warning messages in the dashboard. This may also be the case with other custom post types. I was able to reproduce the issue specifically with Advanced Custom Fields field groups. Note: The notice/warnings only appear if wp_debug is set to true. Which it should be in dev environments.

<img width="1058" alt="Screen Shot 2019-05-21 at 11 13 31 AM" src="https://user-images.githubusercontent.com/3518732/58109414-96c36780-7bbb-11e9-97f9-495e096c28e8.png">


**Issue**

In the Leaky Paywall save_leaky_paywall_content_visibility function there is a user capability check. That check currently uses the capability name 'edit_page'. There is no 'edit_page' capability. See [here](https://wordpress.org/support/article/roles-and-capabilities/) for a full list of the current capabilities.

**Resolution**

I've edited the current_user_can function to check for 'edit_pages' rather than 'edit_page'. edit_pages is an excepted capability.