### PR TITLE
Allow secure cookies

### DIFF
--- a/include/class-restrictions.php
+++ b/include/class-restrictions.php
@@ -853,7 +853,7 @@ class Leaky_Paywall_Restrictions {
 		$viewed_content[$restricted_post_type][$this->post_id] = $this->get_expiration_time();
 		$json_viewed_content = json_encode( $viewed_content );
 
-		$cookie = setcookie( $this->get_cookie_name(), $json_viewed_content, $this->get_expiration_time(), '/' );
+		$cookie = setcookie( $this->get_cookie_name(), $json_viewed_content, $this->get_expiration_time(), '/', '', is_ssl() );
 		$_COOKIE[$this->get_cookie_name()] = $json_viewed_content;
 
 	}


### PR DESCRIPTION
Allow the use of secure cookies if the site is being accessed over HTTPS.

Rationale:
* Several payment vendors flag insecure cookies (regardless of content) as an issue
* To align the plugin code with the way in which most of WordPress core cookies are set
* While the cookie data is not sensitive, there is no harm in using secure cookies

Suggestions:
* Potentially hook into the WP core `secure_auth_cookie` filter?
* Create a plugin-specific `leaky_paywall_restriction_cookie_secure` filter?
* Use a method other than `is_ssl()` for determining whether to use secure cookies?