### PR TITLE
Add configurable retention cleanup for incomplete registration records

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2652,6 +2652,17 @@ if (!function_exists('build_leaky_paywall_subscription_levels_row')) {
 	}
 	register_deactivation_hook(__FILE__, 'leaky_paywall_process_renewal_reminder_deactivation');
 
+	/**
+	 * Register cron job to clean up stale incomplete users.
+	 */
+	function leaky_paywall_incomplete_user_cleanup_schedule()
+	{
+		if (!wp_next_scheduled('leaky_paywall_process_incomplete_user_cleanup')) {
+			wp_schedule_event(time(), 'daily', 'leaky_paywall_process_incomplete_user_cleanup');
+		}
+	}
+	add_action('init', 'leaky_paywall_incomplete_user_cleanup_schedule');
+
 
 	/**
 	 * Process renewal reminder email for each Leaky Paywall subscriber

--- a/include/admin/settings/settings.php
+++ b/include/admin/settings/settings.php
@@ -349,6 +349,14 @@ class Leaky_Paywall_Settings
 					</tr>
 
 					<tr class="general-options">
+						<th><label for="incomplete_user_retention_days"><?php esc_html_e('Incomplete Registration Retention', 'leaky-paywall'); ?></label></th>
+						<td>
+							<input type="number" min="0" id="incomplete_user_retention_days" class="small-text" name="incomplete_user_retention_days" value="<?php echo esc_attr($settings['incomplete_user_retention_days']); ?>" />
+							<p class="description"><?php esc_html_e('Automatically delete incomplete registration records after this many days. Set to 0 to disable automatic cleanup.', 'leaky-paywall'); ?></p>
+						</td>
+					</tr>
+
+					<tr class="general-options">
 						<th><?php esc_html_e('Expiration Dates', 'leaky-paywall'); ?></th>
 						<td><input type="checkbox" id="add_expiration_dates" name="add_expiration_dates" <?php checked('on', $settings['add_expiration_dates']); ?> /> <?php esc_html_e('If a current subscriber renews/changes their subscription level, add additional time to their current expiration date. If unchecked, their new expiration date will be calculated from the date of subscription level renewal/change.', 'leaky-paywall'); ?></td>
 					</tr>
@@ -1520,11 +1528,12 @@ The %sitename% Team';
 				'renewal_reminder_email'                => 'on',
 				'renewal_reminder_email_subject'        => '',
 				'renewal_reminder_email_body'           => '',
-				'renewal_reminder_days_before'          => '7',
-				'new_subscriber_admin_email'            => 'off',
-				'admin_new_subscriber_email_subject'    => 'New subscription on ' . stripslashes_deep(html_entity_decode(get_bloginfo('name'), ENT_COMPAT, 'UTF-8')),
-				'admin_new_subscriber_email_recipients' => get_option('admin_email'),
-				'payment_gateway'                       => array('stripe'),
+					'renewal_reminder_days_before'          => '7',
+					'new_subscriber_admin_email'            => 'off',
+					'admin_new_subscriber_email_subject'    => 'New subscription on ' . stripslashes_deep(html_entity_decode(get_bloginfo('name'), ENT_COMPAT, 'UTF-8')),
+					'admin_new_subscriber_email_recipients' => get_option('admin_email'),
+					'incomplete_user_retention_days'        => 365,
+					'payment_gateway'                       => array('stripe'),
 				'test_mode'                             => 'off',
 				'connected_account_id'                  => '',
 				'lp_app_api_key'                        => '',
@@ -1710,6 +1719,10 @@ The %sitename% Team';
 					$settings['enable_user_delete_account'] = sanitize_text_field(wp_unslash($_POST['enable_user_delete_account']));
 				} else {
 					$settings['enable_user_delete_account'] = 'off';
+				}
+
+				if ( isset( $_POST['incomplete_user_retention_days'] ) ) {
+					$settings['incomplete_user_retention_days'] = absint( wp_unslash( $_POST['incomplete_user_retention_days'] ) );
 				}
 
 				if (!empty($_POST['remove_username_field'])) {

--- a/include/registration-functions.php
+++ b/include/registration-functions.php
@@ -1371,6 +1371,56 @@ function leaky_paywall_cleanup_incomplete_user( $email ) {
 	}
 }
 
+/**
+ * Permanently delete stale incomplete users and their metadata.
+ *
+ * @since 5.0.9
+ */
+function leaky_paywall_process_incomplete_user_cleanup() {
+	$settings = get_leaky_paywall_settings();
+	$retention_days = isset( $settings['incomplete_user_retention_days'] ) ? absint( $settings['incomplete_user_retention_days'] ) : 365;
+	$retention_days = absint( apply_filters( 'leaky_paywall_incomplete_user_retention_days', $retention_days, $settings ) );
+
+	if ( $retention_days < 1 ) {
+		return;
+	}
+
+	$batch_size = absint( apply_filters( 'leaky_paywall_incomplete_user_cleanup_batch_size', 100, $settings ) );
+
+	if ( $batch_size < 1 ) {
+		$batch_size = 100;
+	}
+
+	$cutoff = gmdate( 'Y-m-d H:i:s', strtotime( '-' . $retention_days . ' days' ) );
+
+	$incomplete_users = get_posts(
+		array(
+			'post_type'      => 'lp_incomplete_user',
+			'post_status'    => 'any',
+			'fields'         => 'ids',
+			'posts_per_page' => $batch_size,
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+			'date_query'     => array(
+				array(
+					'column'    => 'post_date_gmt',
+					'before'    => $cutoff,
+					'inclusive' => false,
+				),
+			),
+		)
+	);
+
+	if ( empty( $incomplete_users ) ) {
+		return;
+	}
+
+	foreach ( $incomplete_users as $incomplete_user_id ) {
+		wp_delete_post( $incomplete_user_id, true );
+	}
+}
+add_action( 'leaky_paywall_process_incomplete_user_cleanup', 'leaky_paywall_process_incomplete_user_cleanup' );
+
 function leaky_paywall_create_subscriber_from_incomplete_user( $email ) {
 
 	$incomplete_id = leaky_paywall_get_incomplete_user_from_email( $email );

--- a/leaky-paywall.php
+++ b/leaky-paywall.php
@@ -161,10 +161,15 @@ function leaky_paywall_activate() {
 	if ( get_option( 'leaky_paywall_tracking_allow' ) && ! wp_next_scheduled( 'leaky_paywall_tracking_send' ) ) {
 		wp_schedule_event( time(), 'weekly', 'leaky_paywall_tracking_send' );
 	}
+
+	if ( ! wp_next_scheduled( 'leaky_paywall_process_incomplete_user_cleanup' ) ) {
+		wp_schedule_event( time(), 'daily', 'leaky_paywall_process_incomplete_user_cleanup' );
+	}
 }
 register_activation_hook( __FILE__, 'leaky_paywall_activate' );
 
 function leaky_paywall_deactivate() {
 	wp_clear_scheduled_hook( 'leaky_paywall_tracking_send' );
+	wp_clear_scheduled_hook( 'leaky_paywall_process_incomplete_user_cleanup' );
 }
 register_deactivation_hook( __FILE__, 'leaky_paywall_deactivate' );

--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,9 @@ You can deactivate Leaky Paywall at any time without losing any subscriber data.
 
 == Changelog ==
 
+= 5.0.9 =
+* Add configurable retention for incomplete registration records with scheduled cleanup of stale data
+
 = 5.0.8 =
 * Add list builder to top content conversions
 * Fix save issue in email settings

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,3 +35,4 @@ foreach ( $options as $option ) {
 
 // Clean up the tracking cron.
 wp_clear_scheduled_hook( 'leaky_paywall_tracking_send' );
+wp_clear_scheduled_hook( 'leaky_paywall_process_incomplete_user_cleanup' );


### PR DESCRIPTION
This adds a new General settings field for incomplete registration retention days, defaulting to `365`, and schedules a daily WP-Cron cleanup for stale `lp_incomplete_user` records.

What changed:
- Added a new `incomplete_user_retention_days` setting and UI field in the General settings tab.
- Added sanitization and saving for the new setting.
- Added a WP-Cron cleanup callback that permanently deletes stale incomplete-user posts with `wp_delete_post( $id, true )` so metadata is removed too.
- Scheduled the cleanup on plugin activation and ensured it is also registered for existing installs.
- Cleared the scheduled hook on deactivation and uninstall.
- Added a changelog entry for the new maintenance behavior.
- Also added cleanup to plugin uninstall

Notes:
- Setting durartion to `0` disables automatic cleanup.
- Defaults to 365 days.  Users should set lower if local jurisdiction have stricter PII rules.
- The cleanup uses WordPress deletion APIs instead of raw SQL.

Fixes zeen101/leaky-paywall#111